### PR TITLE
Make compilable with GHC 7.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.aux
 *.hp
 *.prof
+dist/
+.cabal-sandbox
+cabal.sandbox.config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+# NB: don't set `language: haskell` here
+
+# See also https://github.com/hvr/multi-ghc-travis for more information
+env:
+# - GHCVER=7.6.3 CABALVER=1.16
+ - GHCVER=7.8.4 CABALVER=1.18
+ - GHCVER=7.10.1 CABALVER=1.22
+ - GHCVER=head CABALVER=head
+
+matrix:
+  allow_failures:
+   - env: GHCVER=head CABALVER=head
+
+branches:
+  only:
+    - master
+
+# Note: the distinction between `before_install` and `install` is not
+#       important.
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - cabal --version
+
+install:
+ - travis_retry cabal update
+ - cabal install --only-dependencies --enable-tests
+
+# Here starts the actual work to be performed for the package under
+# test; any command which exits with a non-zero exit code causes the
+# build to fail.
+script:
+ # -v2 provides useful information for debugging
+ - cabal configure -v2 --enable-tests
+
+ # this builds all libraries and executables
+ # (including tests/benchmarks)
+ - cabal build
+ - cabal test
+
+ # tests that a source-distribution can be generated
+ - cabal sdist
+
+ # check that the generated source-distribution can be built & installed
+ - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
+   cd dist/;
+   if [ -f "$SRC_TGZ" ]; then
+      cabal install --force-reinstalls "$SRC_TGZ";
+   else
+      echo "expected '$SRC_TGZ' not found";
+      exit 1;
+   fi
+
+# EOF

--- a/Earley.cabal
+++ b/Earley.cabal
@@ -21,7 +21,7 @@ source-repository    head
 library
   exposed-modules:     Text.Earley.Derived, Text.Earley.Grammar, Text.Earley.Parser Text.Earley
   -- other-modules:
-  build-depends:       base ==4.8.*, containers >=0.5, ListLike >=4.1
+  build-depends:       base >=4.7 && <4.9, containers >=0.5, ListLike >=4.1
   -- hs-source-dirs:
   default-language:    Haskell2010
   ghc-options:         -Wall -funbox-strict-fields -O2

--- a/Text/Earley/Grammar.hs
+++ b/Text/Earley/Grammar.hs
@@ -1,5 +1,5 @@
 -- | Context-free grammars.
-{-# LANGUAGE GADTs, RankNTypes #-}
+{-# LANGUAGE CPP, GADTs, RankNTypes #-}
 module Text.Earley.Grammar
   ( Prod(..)
   , satisfy
@@ -10,6 +10,9 @@ module Text.Earley.Grammar
 import Control.Applicative
 import Control.Monad
 import Control.Monad.Fix
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid
+#endif
 
 infixr 0 <?>
 

--- a/Text/Earley/Parser.hs
+++ b/Text/Earley/Parser.hs
@@ -1,5 +1,5 @@
 -- | Parsing.
-{-# LANGUAGE BangPatterns, DeriveFunctor, GADTs, Rank2Types #-}
+{-# LANGUAGE CPP, BangPatterns, DeriveFunctor, GADTs, Rank2Types #-}
 module Text.Earley.Parser
   ( Report(..)
   , Result(..)
@@ -17,6 +17,9 @@ import Data.ListLike(ListLike)
 import qualified Data.ListLike as ListLike
 import Data.STRef.Lazy
 import Text.Earley.Grammar
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid
+#endif
 
 -------------------------------------------------------------------------------
 -- * Concrete rules and productions


### PR DESCRIPTION
I used CPP so it compiles without warnings with both GHC [7.10](https://travis-ci.org/phadej/Earley/jobs/61418960) and [7.8](https://travis-ci.org/phadej/Earley/jobs/61418959)

As a bonus, you could setup travis ci (IIRC I originally copied it from [containers package](https://github.com/haskell/containers/blob/master/.travis.yml))

And also added stuff to `.gitignore`