### PR TITLE
Decrease lower bound on `base` dependency to `4.6`

### DIFF
--- a/Earley.cabal
+++ b/Earley.cabal
@@ -42,7 +42,7 @@ library
                        Text.Earley.Internal,
                        Text.Earley.Mixfix,
                        Text.Earley.Parser
-  build-depends:       base >=4.7 && <4.9, ListLike >=4.1
+  build-depends:       base >=4.6 && <4.9, ListLike >=4.1
   default-language:    Haskell2010
   ghc-options:         -Wall
                        -funbox-strict-fields


### PR DESCRIPTION
This is so that `Earley` builds against `ghc-7.6.3`