### PR TITLE
Add a generalized version of `word` to Derived.hs

### DIFF
--- a/Text/Earley.hs
+++ b/Text/Earley.hs
@@ -3,7 +3,7 @@ module Text.Earley
   ( -- * Context-free grammars
     Prod, satisfy, (<?>), Grammar, rule
   , -- * Derived operators
-    symbol, namedSymbol, word
+    symbol, namedSymbol, word, word'
   , -- * Parsing
     Report(..), Result(..), parser, allParses, fullParses
     -- * Recognition

--- a/Text/Earley/Derived.hs
+++ b/Text/Earley/Derived.hs
@@ -1,6 +1,8 @@
 -- | Derived operators.
 module Text.Earley.Derived where
 import Control.Applicative hiding (many)
+import Data.ListLike (ListLike)
+import qualified Data.ListLike as ListLike
 
 import Text.Earley.Grammar
 
@@ -16,3 +18,7 @@ namedSymbol x = symbol x <?> x
 {-# INLINE word #-}
 word :: Eq t => [t] -> Prod r e t [t]
 word = foldr (liftA2 (:) . satisfy . (==)) (pure [])
+
+{-# INLINE word' #-}
+word' :: (ListLike i t, Eq t) => i -> Prod r e t [t]
+word' = foldr (\a b -> liftA2 (:) (satisfy (a ==)) b) (pure []) . ListLike.toList


### PR DESCRIPTION
Follow-up to #21.

I'm not sure if it's better to replace `word` altogether with this generalized version, or to simply add a new function `word'`. 

I believe there wouldn't be problems with replacing `word` with `word'` with string literals and OverloadedStrings, because when the compiler sees `word' "hello"`, I think it assumes `"hello"` is a `String` by default, which is a reasonable behavior here. Anyhow, I had no errors compiling the tests after adding `OverloadedStrings` and replacing `word` with `word'` in the tests. 

(By the way, if we choose to keep both functions, we can simplify the implementation of `word'` to

```haskell
word' = word . ListLike.toList
```
)