### PR TITLE
Fix examples

### DIFF
--- a/examples/Expr2.hs
+++ b/examples/Expr2.hs
@@ -16,13 +16,13 @@ grammar = mdo
 
   whitespace <- rule $ many $ satisfy isSpace
 
-  let token :: Prod r String Char a -> Prod r String Char a
-      token p = whitespace *> p
+  let tok :: Prod r String Char a -> Prod r String Char a
+      tok p   = whitespace *> p
 
-      sym x   = token $ token x <?> [x]
+      sym x   = tok $ token x <?> [x]
 
-      ident   = token $ (:) <$> satisfy isAlpha <*> many (satisfy isAlphaNum) <?> "identifier"
-      num     = token $ some (satisfy isDigit) <?> "number"
+      ident   = tok $ (:) <$> satisfy isAlpha <*> many (satisfy isAlphaNum) <?> "identifier"
+      num     = tok $ some (satisfy isDigit) <?> "number"
 
   expr0 <- rule
      $ (Lit . read)  <$> num

--- a/examples/Infinite.hs
+++ b/examples/Infinite.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE RecursiveDo #-}
-module Testa where
 import Control.Applicative
 import Text.Earley
 


### PR DESCRIPTION
Thanks for making this package. I wanted to try out the examples and noticed that two of them didn't compile:

  * Type error in `Expr2.hs`. It looks like `symbol` was renamed to `token` but the Expr2 example already defined a function locally named `token` and so it was getting mysterious looking type errors. Renaming the local definition to `tok` and updating the uses fixed the problem.
  * No `Main` module in `Infinite.hs`. An explicit module name was given, so I just removed it. With the explicit module name ghc was refusing to generate the binary so `cabal install -fexamples` was failing to find the `early-infinite` binary and erroring out as a result.