### PR TITLE
Add missing module in test

### DIFF
--- a/Earley.cabal
+++ b/Earley.cabal
@@ -146,4 +146,5 @@ test-suite tests
                        Mixfix,
                        Optional,
                        ReversedWords,
+                       UnbalancedPars,
                        VeryAmbiguous


### PR DESCRIPTION
As seen on Hackage - http://hackage.haskell.org/package/Earley-0.13.0.0/src/ package archive contains no `UnbalancedPars` module which results in test failure seen in https://github.com/commercialhaskell/stackage/issues/4193
This PR fixes the situation (but in the end a new Hackage release is required)