### PR TITLE
Scrub `satisfyMaybe`; note `terminal` in docs of `satisfy`

### DIFF
--- a/Text/Earley.hs
+++ b/Text/Earley.hs
@@ -3,7 +3,7 @@ module Text.Earley
   ( -- * Context-free grammars
     Prod, terminal, (<?>), Grammar, rule
   , -- * Derived operators
-    satisfy, satisfyMaybe, token, namedToken, list, listLike
+    satisfy, token, namedToken, list, listLike
   , -- * Parsing
     Report(..), Parser.Result(..), Parser, parser, allParses, fullParses
   , -- * Recognition

--- a/Text/Earley/Derived.hs
+++ b/Text/Earley/Derived.hs
@@ -8,16 +8,10 @@ import qualified Data.ListLike as ListLike
 import Text.Earley.Grammar
 
 -- | Match a token that satisfies the given predicate. Returns the matched
--- token.
+-- token. See also 'terminal'.
 {-# INLINE satisfy #-}
 satisfy :: (t -> Bool) -> Prod r e t t
-satisfy p = satisfyMaybe ((<$) <*> guard . p)
-
--- | Match a token that satisfies the given predicate. Returns the produced
--- value.
-{-# INLINE satisfyMaybe #-}
-satisfyMaybe :: (t -> Maybe a) -> Prod r e t a
-satisfyMaybe f = Terminal f $ Pure id
+satisfy p = terminal ((<$) <*> guard . p)
 
 -- | Match a single token.
 token :: Eq t => t -> Prod r e t t


### PR DESCRIPTION
See #47.

Turns out `satisfyMaybe` is exactly `terminal`. However, i somehow failed to find the latter while seeking such a function. Ergo, scrub `satisfyMaybe` and point to `terminal` in the docs of `satisfy`.
