### PR TITLE
Add Text.Earley.nextToken

### DIFF
--- a/Text/Earley.hs
+++ b/Text/Earley.hs
@@ -3,7 +3,7 @@ module Text.Earley
   ( -- * Context-free grammars
     Prod, terminal, (<?>), Grammar, rule
   , -- * Derived operators
-    satisfy, token, namedToken, list, listLike
+    satisfy, token, namedToken, list, listLike, nextToken
   , -- * Parsing
     Report(..), Parser.Result(..), Parser, parser, allParses, fullParses
   , -- * Recognition


### PR DESCRIPTION
This new function lets production rules inspect the next token. Parsing decisions can't be made from this lookahead, so the grammar remains context free. One application of this new function is to extract location information from tokens - if the user has tokens with location information, we can use `liftA2 addLocation nextToken r` to run `r`, while also inspecting the first token `r` consumed. For example,

```haskell
located
  :: Prod r Text (T.Located T.Token) Syntax
  -> Prod r Text (T.Located T.Token) Syntax
located p = do
  ~(T.Located x y _) <- nextToken
  syntax <- p
  return case syntax of
    At _ _ s -> At x y s
    s        -> At x y s
```