### PR TITLE
Add constraint validation feature

### DIFF
--- a/Earley.cabal
+++ b/Earley.cabal
@@ -133,9 +133,10 @@ test-suite tests
   ghc-options:         -Wall
   hs-source-dirs:      tests
   default-language:    Haskell2010
-  build-depends:       base, Earley, tasty >=0.10, tasty-quickcheck >=0.8, tasty-hunit >= 0.9, QuickCheck >= 2.8
+  build-depends:       base, Earley, tasty >=0.10, tasty-quickcheck >=0.8, tasty-hunit >= 0.9, QuickCheck >= 2.8, containers >= 0.6
   other-modules:
                        Arbitrary,
+                       Constraint,
                        Empty,
                        Expr,
                        Generator,

--- a/Text/Earley.hs
+++ b/Text/Earley.hs
@@ -1,9 +1,9 @@
 -- | Parsing all context-free grammars using Earley's algorithm.
 module Text.Earley
   ( -- * Context-free grammars
-    Prod, terminal, (<?>), Grammar, rule
+    Prod, terminal, (<?>), constraint, Grammar, rule
   , -- * Derived operators
-    satisfy, token, namedToken, list, listLike
+    satisfy, token, namedToken, anyToken, list, listLike, matches
   , -- * Parsing
     Report(..), Parser.Result(..), Parser, parser, allParses, fullParses
   , -- * Recognition

--- a/Text/Earley/Derived.hs
+++ b/Text/Earley/Derived.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Rank2Types #-}
 -- | Derived operators.
 module Text.Earley.Derived where
 import Control.Applicative hiding (many)
@@ -6,6 +7,7 @@ import Data.ListLike(ListLike)
 import qualified Data.ListLike as ListLike
 
 import Text.Earley.Grammar
+import Text.Earley.Parser
 
 -- | Match a token that satisfies the given predicate. Returns the matched
 -- token. See also 'terminal'.
@@ -21,6 +23,10 @@ token x = satisfy (== x)
 namedToken :: Eq t => t -> Prod r t t t
 namedToken x = token x <?> x
 
+-- | Match a single token with any value
+anyToken :: Prod r e t t
+anyToken = terminal Just
+
 -- | Match a list of tokens in sequence.
 {-# INLINE list #-}
 list :: Eq t => [t] -> Prod r e t [t]
@@ -30,3 +36,6 @@ list = listLike
 {-# INLINE listLike #-}
 listLike :: (Eq t, ListLike i t) => i -> Prod r e t i
 listLike = ListLike.foldr (liftA2 ListLike.cons . satisfy . (==)) (pure ListLike.empty)
+
+matches :: ListLike i t => (forall r. Grammar r (Prod r e t a)) -> i -> Bool
+matches grammar = not . null . fst . fullParses (parser grammar)

--- a/Text/Earley/Derived.hs
+++ b/Text/Earley/Derived.hs
@@ -37,5 +37,7 @@ list = listLike
 listLike :: (Eq t, ListLike i t) => i -> Prod r e t i
 listLike = ListLike.foldr (liftA2 ListLike.cons . satisfy . (==)) (pure ListLike.empty)
 
+-- | Whether or not the grammar matches the input string. Equivalently,
+-- whether the given input is in the language described by the grammars.
 matches :: ListLike i t => (forall r. Grammar r (Prod r e t a)) -> i -> Bool
 matches grammar = not . null . fst . fullParses (parser grammar)

--- a/Text/Earley/Grammar.hs
+++ b/Text/Earley/Grammar.hs
@@ -4,6 +4,7 @@ module Text.Earley.Grammar
   ( Prod(..)
   , terminal
   , (<?>)
+  , constraint
   , alts
   , Grammar(..)
   , rule
@@ -54,6 +55,8 @@ data Prod r e t a where
   Many        :: !(Prod r e t a) -> !(Prod r e t ([a] -> b)) -> Prod r e t b
   -- Error reporting.
   Named       :: !(Prod r e t a) -> e -> Prod r e t a
+  -- Non-context-free extension: conditioning on the parsed output.
+  Constraint  :: !(Prod r e t a) -> (a -> Bool) -> Prod r e t a
 
 -- | Match a token for which the given predicate returns @Just a@,
 -- and return the @a@.
@@ -63,6 +66,10 @@ terminal p = Terminal p $ Pure id
 -- | A named production (used for reporting expected things).
 (<?>) :: Prod r e t a -> e -> Prod r e t a
 (<?>) = Named
+
+-- | A parser that filters results, post-parsing
+constraint :: (a -> Bool) -> Prod r e t a -> Prod r e t a
+constraint = flip Constraint
 
 -- | Lifted instance: @(<>) = 'liftA2' ('<>')@
 instance Semigroup a => Semigroup (Prod r e t a) where

--- a/tests/Constraint.hs
+++ b/tests/Constraint.hs
@@ -1,0 +1,55 @@
+module Constraint where
+import Control.Applicative
+import Data.List
+import Data.Set(fromList)
+
+import Test.Tasty
+import Test.Tasty.HUnit as HU
+
+import Text.Earley
+
+oneToken :: Grammar r (Prod r () t t)
+oneToken = rule anyToken
+
+someTokens :: Grammar r (Prod r () t [t])
+someTokens = rule (some anyToken)
+
+tests :: TestTree
+tests = testGroup "New features"
+  [ HU.testCase "anyToken1" $
+      let input = "hello"
+          l     = length input in
+      allParses (parser oneToken) input
+      @?= (,) [('h', 1)] Report { position   = 1
+                                , expected   = []
+                                , unconsumed = drop 1 input
+                                }
+  , HU.testCase "anyToken2" $
+      allParses (parser oneToken) ""
+      @?= (,) [] Report { position = 0
+                        , expected   = []
+                        , unconsumed = ""
+                        }
+  , HU.testCase "anyToken3" $
+      let input = "hello"
+          l     = length input in
+      allParses (parser someTokens) input
+      @?= (,) [(init, length init) | init <- inits input, not (null init) ]
+              Report { position   = l
+                     , expected   = []
+                     , unconsumed = []
+                     }
+  , HU.testCase "constraint" $
+      matches noRepeats "salut"
+      @?= True
+  , HU.testCase "constraint2" $
+      matches noRepeats "hello"
+      @?= False
+  , HU.testCase "constraint3" $
+      fromList (map fst $ exactly 2 $ generator noRepeats "abcd")
+      @?= fromList [[x, y] | x <- "abcd", y <- "abcd", x /= y]
+  ]
+
+noRepeats = rule $
+  constraint (\x -> length x == length (fromList x)) $
+    many anyToken

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 import Test.Tasty
 
+import qualified Constraint
 import qualified Empty
 import qualified Expr
 import qualified Generator
@@ -16,7 +17,8 @@ import qualified VeryAmbiguous
 
 main :: IO ()
 main = defaultMain $ testGroup "Tests"
-  [ Empty.tests
+  [ Constraint.tests
+  , Empty.tests
   , Expr.tests
   , Generator.tests
   , InlineAlts.tests


### PR DESCRIPTION
Hi!
I'm getting back into Haskell after a long break, and decided to use Earley as a parser in my project - I've wrote enough recursive descent parsers, both manually and with Parsec writing the boilerplate, and decided to let the computer do the hard work for once :)

Adding here a feature that I didn't have a use for yet, but is a neat property of Earley-type parsers: it's possible to implement arbitrary conditions in the grammar, usually with only a small impact on efficiency.
This idea is also referred to by #50, and a real-world use case would be for parsing command lines. Many programs allow arbitrary orders, but require that each flag appears only once. In order to express this as a CFG, you need an exponential number of productions. With constraint validations, it's possible to specify that the valid options at each point are exactly those that didn't appear before.

Other small stuff -
In my project I used "any terminal" several times in the grammar, and it feels like a useful addition to the library. In my own tests I found the "matches" predicate useful. So I've added them here too. They don't really belong so we can remove them from the PR or merge separately. The same goes for the unit test file, it's the first time I'm writing unit tests in Haskell and they may not fit here.